### PR TITLE
fix: remove .only modifier from test to fix CI

### DIFF
--- a/packages/bridge/bridge-react/__tests__/bridge.spec.tsx
+++ b/packages/bridge/bridge-react/__tests__/bridge.spec.tsx
@@ -103,7 +103,7 @@ describe('bridge', () => {
     expect(ref.current).not.toBeNull();
   });
 
-  it.only('createRemoteComponent with custom createRoot prop', async () => {
+  it('createRemoteComponent with custom createRoot prop', async () => {
     const renderMock = vi.fn();
 
     function Component({ props }: { props?: Record<string, any> }) {


### PR DESCRIPTION
This PR fixes the failing CI test in PR #3544 by removing the `.only` modifier in `packages/bridge/bridge-react/__tests__/bridge.spec.tsx`. This modifier was causing Vitest to fail in CI environments with the error: `[Vitest] Unexpected .only modifier`.

I've verified locally that with the `.only` modifier, tests fail when run with `--no-allowOnly` flag (which matches CI behavior), and that removing it resolves the issue.

## Related Issue
- Helps unblock PR #3544
- Related to issue #3537 (Support React v19 in @module-federation/bridge-react)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] All new and existing tests passed.

This small change should allow the important React 19 compatibility work in PR #3544 to proceed.